### PR TITLE
Fix: Use Debian Stable to support ARM64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,16 @@
 ARG version
 
-FROM alpine/curl as installer
+# We would rather use Alpine, but we want ARM64 and misses
+# aarch64 musl binaries from the Rover project.
+FROM debian:stable-slim as installer
 ARG version
+
+# install script needs curl or wget
+RUN apt update && apt install -y curl
 
 RUN curl -sSL https://rover.apollo.dev/nix/${version} | sh
 
-FROM alpine as runner
+FROM debian:stable-slim as runner
 
 COPY --from=installer /root/.rover/bin/rover /root/.rover/bin/rover
 ENV PATH="/root/.rover/bin:${PATH}"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# rover
+
+_A docker wrapper for rover CLI [https://www.apollographql.com/docs/rover/getting-started](https://www.apollographql.com/docs/rover/getting-started)_.
+
+Our small little project to build a Docker Image for [Apollo Rover](https://github.com/apollographql/rover), as no official images are supplied.
+
+Images pushed to our Docker Hub as [`worksome/rover`](https://hub.docker.com/r/worksome/rover).
+
+## Tags
+
+Our image tags follows [rover release versions](https://github.com/apollographql/rover/releases) without the `v` prefix.
+
+We apply the mutable tag `latest` to most recent image we built based on a _non-prelease_ version of Rover.
+
+## ARM architecture support
+
+AMD/ARM multi-architecture image are built based on Debian stable-slim base images, and Rover binaries installed through official install script which fetches from  Github releases. ARM 64-bit is expected to install `aarch64-unknown-linux-gnu` releases, while ARM 64-bit is expected to install `x86_64-unknown-linux-gnu`.
+
+We can't build smaller Alpine Linux bases images, due to Rover not releasing `musl` binaries for `aarch64`, which would be requires for Alpine Linux that don't have glibc support. We don't want to build from sources, and maintain a more detailed build process.
+
+Notice it was first with the version [`v0.9.2-rc.1`](https://github.com/apollographql/rover/releases/tag/v0.9.2-rc.1) of Rover, ARM 64-bit was supported with release binaries[[1]],[[2]] and our Docker Image support ARM 64-bit as architecture was wrongly detected in our project as we based images on Alpine.
+
+[1]: https://github.com/apollographql/rover/pull/1137
+[2]: https://github.com/apollographql/rover/pull/1356


### PR DESCRIPTION
Switch from Alpine to use Debian Stable as base image, as rover now have aarch64 binaries released from version 0.9.2-rc.1 but only for glibc supported distros on ARM.

Alpine uses musl and there are only x86_64 binaries released by Rover for these.

Also add more information around this in the README.